### PR TITLE
Refactor components and update LoadingSkeleton usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-<div align="center">
-  <img src="apcpro-web/public/images/logo-na-capa.png" alt="Logo" height="200">
-
   <h1>APC FIT PRO</h1>
   
   <p><strong>Plataforma Completa para Avaliação, Prescrição e Controle de Treinos Físicos</strong></p>
@@ -31,7 +28,9 @@
 
 # Introdução
 
-O **APC FIT PRO** é uma plataforma completa para prescrição, avaliação e controle de treinos físicos, unindo ciência e tecnologia para revolucionar a experiência de profissionais de educação física e alunos. Baseado no método **"Avaliar, Planejar e Controlar" (APC)**, oferece avaliação detalhada, planejamento personalizado e controle preciso de carga em uma única solução.
+# Introdução
+
+O **APC FIT PRO** é uma plataforma completa para prescrição, avaliação e controle de treinos físicos, unindo ciência e tecnologia para revolucionar a experiência de profissionais de educação física e alunos. Baseado no método **"Avaliar, Planejar e Controlar" (APC)**, oferece avaliação detalhada, planejamento personalizado e controle preciso de carga em uma única solução. O grande diferencial está na personalização avançada, integração entre profissionais e alunos, e ajustes contínuos para otimizar resultados.
 
 ## 🎯 Principais Características
 
@@ -49,21 +48,6 @@ O **APC FIT PRO** é uma plataforma completa para prescrição, avaliação e co
 - **Diferencial:** Personalização avançada, integração entre profissionais e alunos, e ajustes contínuos para otimizar resultados.
 - **Público-Alvo:** Profissionais de Educação Física e seus alunos
 - **Modalidade:** Plataforma Web Progressive (PWA)er">
-  <img src="apcpro-web/public/images/logo-na-capa.png" alt="Logo" height="200">
-
-  <h1>APC FIT PRO</h1>
-</div>
-
-# Introdução
-
-O APC FIT PRO é uma plataforma completa para prescrição, avaliação e controle de treinos físicos, unindo ciência e tecnologia para revolucionar a experiência de profissionais de educação física e alunos. Baseado no método “Avaliar, Planejar e Controlar” (APC), oferece avaliação detalhada, planejamento personalizado e controle preciso de carga em uma única solução. O grande diferencial está na personalização avançada, integração entre profissionais e alunos, e ajustes contínuos para otimizar resultados.
-
----
-
-# Visão Geral do Projeto
-
-- **Objetivo:** Oferecer avaliações detalhadas, planejamento personalizado e controle preciso de treinos, tudo em um só lugar, com base no método APC.
-- **Diferencial:** Personalização avançada, integração entre profissionais e alunos, e ajustes contínuos para otimizar resultados.
 
 ---
 

--- a/apcpro-web/src/app/dashboard/page.tsx
+++ b/apcpro-web/src/app/dashboard/page.tsx
@@ -1,7 +1,21 @@
 "use client";
 
+import { Suspense } from "react";
 import { Dashboard } from "@/components/Dashboard";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function DashboardPage() {
-  return <Dashboard />;
+  return (
+    <Suspense
+      fallback={
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-8 w-1/2" />
+        </div>
+      }
+    >
+      <Dashboard />
+    </Suspense>
+  );
 }

--- a/apcpro-web/src/app/dashboard/professores/page.tsx
+++ b/apcpro-web/src/app/dashboard/professores/page.tsx
@@ -287,44 +287,33 @@ export default function ProfessoresDashboard() {
       </div>
       {/* Header com filtros avançados */}
       <div className="flex flex-col gap-4">
-        <div className="flex flex-row items-center gap-3 justify-between">
-          <div className="flex items-center gap-3">
-            <div className="max-w-xs">
-              <TeamSwitcher 
-                teams={[]} 
-                onTeamChange={(groupId) => setGrupoSelecionado(groupId)}
-              />
-            </div>
-            <Button
-              variant="outline"
-              onClick={() => setModalGerenciarGruposOpen(true)}
-              aria-label="Gerenciar grupos"
-            >
-              <Users className="h-4 w-4 mr-2" />
-              Gerenciar Grupos
-            </Button>
-            <Button
-              variant="default"
-              onClick={() => setModalConviteOpen(true)}
-              aria-label="Adicionar novo aluno"
-            >
-              + Novo aluno
-            </Button>
+        <div className="flex flex-wrap items-center gap-2 sm:gap-4 w-full mb-4">
+          <div className="max-w-xs">
+            <TeamSwitcher 
+              teams={[]}
+              onTeamChange={(groupId) => setGrupoSelecionado(groupId)}
+              onGerenciarGruposClick={() => setModalGerenciarGruposOpen(true)}
+            />
           </div>
-          <div className="flex items-center gap-2">
-            <Button variant="outline" size="icon" aria-label="Notificações">
-              <Bell className="h-5 w-5" />
-            </Button>
-          </div>
+          <Button
+            variant="default"
+            onClick={() => setModalConviteOpen(true)}
+            aria-label="Adicionar novo aluno"
+            className="shrink-0"
+          >
+            + Novo aluno
+          </Button>
+          <Button variant="outline" size="icon" aria-label="Notificações">
+            <Bell className="h-5 w-5" />
+          </Button>
+          <FiltrosAvancados
+            busca={busca}
+            onBuscaChange={setBusca}
+            filtros={filtros}
+            onFiltrosChange={setFiltros}
+            grupos={grupos}
+          />
         </div>
-        
-        <FiltrosAvancados
-          busca={busca}
-          onBuscaChange={setBusca}
-          filtros={filtros}
-          onFiltrosChange={setFiltros}
-          grupos={grupos}
-        />
       </div>
       <ConviteAlunoModal
         open={modalConviteOpen}

--- a/apcpro-web/src/components/AvaliacoesPendentes.tsx
+++ b/apcpro-web/src/components/AvaliacoesPendentes.tsx
@@ -228,67 +228,58 @@ export function AvaliacoesPendentes({ professorId, onAtualizacao }: AvaliacoesPe
   const renderizarItemAvaliacao = (avaliacao: AvaliacaoPendente, compacto = false) => (
     <div
       key={avaliacao.id}
-      className={`flex items-center justify-between p-4 border rounded-lg hover:bg-gray-50 transition-colors ${
-        compacto ? 'p-3' : ''
-      }`}
+      className={`flex flex-col sm:flex-row sm:items-center justify-between p-3 sm:p-4 border rounded-lg hover:bg-gray-50 transition-colors gap-3 sm:gap-0 w-full`}
     >
-      <div className="flex-1">
-        <div className="flex items-center gap-3 mb-2">
-          <User className="h-4 w-4 text-gray-500" />
-          <span className="font-medium">{avaliacao.userPerfil.user.name}</span>
-          <Badge className="bg-yellow-100 text-yellow-800">
-            {formatarTipo(avaliacao.tipo)}
-          </Badge>
+      <div className="flex-1 min-w-0 w-full">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3 mb-2 w-full">
+          <span className="flex items-center gap-1 min-w-0 w-full sm:w-auto">
+            <User className="h-4 w-4 text-gray-500 shrink-0" />
+            <span className="font-medium truncate max-w-full sm:max-w-[180px]" title={avaliacao.userPerfil.user.name}>{avaliacao.userPerfil.user.name}</span>
+          </span>
+          <Badge className="bg-yellow-100 text-yellow-800 whitespace-nowrap w-fit sm:w-auto mt-1 sm:mt-0">{formatarTipo(avaliacao.tipo)}</Badge>
         </div>
-        
-        <div className="flex items-center gap-4 text-sm text-gray-600">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 text-sm text-gray-600 w-full">
           <div className="flex items-center gap-1">
             <Calendar className="h-4 w-4" />
-            <span>
-              {new Date(avaliacao.data).toLocaleDateString('pt-BR')}
-            </span>
+            <span>{new Date(avaliacao.data).toLocaleDateString('pt-BR')}</span>
           </div>
           {!compacto && (
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-1 min-w-0 w-full sm:w-auto">
               <FileText className="h-4 w-4" />
-              <span>{avaliacao.userPerfil.user.email}</span>
+              <span className="truncate max-w-full sm:max-w-[200px]" title={avaliacao.userPerfil.user.email}>{avaliacao.userPerfil.user.email}</span>
             </div>
           )}
         </div>
-        
         {!compacto && formatarResultado(avaliacao.resultado, avaliacao.tipo) && (
-          <div className="mt-2 text-sm text-gray-500">
+          <div className="mt-2 text-sm text-gray-500 break-words w-full">
             {formatarResultado(avaliacao.resultado, avaliacao.tipo)}
           </div>
         )}
       </div>
-
-      <div className="flex items-center gap-2">
+      <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto justify-end items-stretch sm:items-center mt-2 sm:mt-0">
         <Button
           size="sm"
           variant="ghost"
           onClick={() => setModalDetalhes({ open: true, avaliacao })}
-          className="text-blue-600 hover:bg-blue-50"
+          className="text-blue-600 hover:bg-blue-50 w-full sm:w-auto"
         >
           <Eye className="h-4 w-4" />
           {!compacto && <span className="ml-1">Ver</span>}
         </Button>
-        
         <Button
           size="sm"
           variant="outline"
-          className="text-green-600 border-green-600 hover:bg-green-50"
+          className="text-green-600 border-green-600 hover:bg-green-50 w-full sm:w-auto"
           onClick={() => setModalAprovacao({ open: true, avaliacao })}
           disabled={processando === avaliacao.id}
         >
           <CheckCircle className="h-4 w-4" />
           {!compacto && <span className="ml-1">Aprovar</span>}
         </Button>
-        
         <Button
           size="sm"
           variant="outline"
-          className="text-red-600 border-red-600 hover:bg-red-50"
+          className="text-red-600 border-red-600 hover:bg-red-50 w-full sm:w-auto"
           onClick={() => setModalReprovacao({ open: true, avaliacao })}
           disabled={processando === avaliacao.id}
         >
@@ -467,7 +458,7 @@ export function AvaliacoesPendentes({ professorId, onAtualizacao }: AvaliacoesPe
 
       {/* Modal de Lista Completa */}
       <Dialog open={modalListaCompleta} onOpenChange={setModalListaCompleta}>
-        <DialogContent className="max-w-4xl max-h-[80vh] overflow-hidden">
+        <DialogContent className="w-full max-w-lg sm:max-w-4xl max-h-[80vh] overflow-hidden">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <List className="h-5 w-5" />
@@ -478,11 +469,9 @@ export function AvaliacoesPendentes({ professorId, onAtualizacao }: AvaliacoesPe
               Lista completa de avaliações aguardando aprovação
             </DialogDescription>
           </DialogHeader>
-
-          <div className="overflow-y-auto max-h-[60vh] space-y-3">
+          <div className="overflow-y-auto max-h-[60vh] space-y-2 pr-1">
             {avaliacoes.map((avaliacao) => renderizarItemAvaliacao(avaliacao, true))}
           </div>
-
           <DialogFooter>
             <Button variant="outline" onClick={() => setModalListaCompleta(false)}>
               Fechar

--- a/apcpro-web/src/components/DobrasCutaneas.tsx
+++ b/apcpro-web/src/components/DobrasCutaneas.tsx
@@ -1,10 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
-import { Alert, AlertDescription } from '@/components/ui/alert';
 import { LoadingButton } from '@/components/ui/Loading';
 
 import {

--- a/apcpro-web/src/components/ExemploDashboardCompleto.tsx
+++ b/apcpro-web/src/components/ExemploDashboardCompleto.tsx
@@ -225,7 +225,7 @@ export function ExemploDashboardCompleto() {
           <div>
             <h4 className="font-semibold text-sm">🔹 Cards de Métricas:</h4>
             <p className="text-sm text-muted-foreground">
-              Use <code className="bg-gray-100 px-1 rounded">LoadingSkeleton variant="card"</code> 
+              Use <code className="bg-gray-100 px-1 rounded">LoadingSkeleton variant=&quot;card&quot;</code> 
               para cada card de métrica durante o carregamento.
             </p>
           </div>
@@ -233,7 +233,7 @@ export function ExemploDashboardCompleto() {
           <div>
             <h4 className="font-semibold text-sm">🔹 Alertas e Listas:</h4>
             <p className="text-sm text-muted-foreground">
-              Use <code className="bg-gray-100 px-1 rounded">LoadingSkeleton variant="list"</code> 
+              Use <code className="bg-gray-100 px-1 rounded">LoadingSkeleton variant=&quot;list&quot;</code> 
               para itens de alertas, notificações e listas simples.
             </p>
           </div>
@@ -241,7 +241,7 @@ export function ExemploDashboardCompleto() {
           <div>
             <h4 className="font-semibold text-sm">🔹 Perfis de Alunos:</h4>
             <p className="text-sm text-muted-foreground">
-              Use <code className="bg-gray-100 px-1 rounded">LoadingSkeleton variant="profile" showAvatar</code> 
+              Use <code className="bg-gray-100 px-1 rounded">LoadingSkeleton variant=&quot;profile&quot; showAvatar</code> 
               para cards de alunos com avatar e informações pessoais.
             </p>
           </div>

--- a/apcpro-web/src/components/ExemplosLoading.tsx
+++ b/apcpro-web/src/components/ExemplosLoading.tsx
@@ -9,6 +9,7 @@ import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Loading, { LoadingInline, LoadingButton, LoadingSkeleton } from '@/components/ui/Loading';
+import Image from "next/image";
 
 export function ExemplosLoading() {
   const [loading1, setLoading1] = useState(false);
@@ -196,10 +197,13 @@ export function ExemplosLoading() {
                 {/* Card Real */}
                 <Card>
                   <CardContent className="p-4">
-                    <img 
+                    <Image 
                       src="/api/placeholder/400/200" 
                       alt="Exemplo"
+                      width={400}
+                      height={200}
                       className="w-full h-48 object-cover rounded-lg mb-4"
+                      priority
                     />
                     <h3 className="font-semibold text-lg mb-2">Título do Card</h3>
                     <p>Descrição do conteúdo do card após carregamento.</p>

--- a/apcpro-web/src/components/ModalGerenciarGrupos.tsx
+++ b/apcpro-web/src/components/ModalGerenciarGrupos.tsx
@@ -4,19 +4,10 @@ import React, { useState, useEffect, useCallback } from "react";
 import { ModalPadrao } from "@/components/ui/ModalPadrao";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Checkbox } from "@/components/ui/checkbox";
-import { 
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { 
   Users, 
   UserPlus, 
@@ -44,10 +35,10 @@ type Aluno = {
   }>;
 };
 
+// Remover do tipo Grupo:
 type Grupo = {
   id: string;
   nome: string;
-  descricao?: string;
   criadoEm: string;
   membros?: Aluno[];
 };
@@ -71,10 +62,6 @@ export function ModalGerenciarGrupos({
   const [alunosSelecionados, setAlunosSelecionados] = useState<string[]>([]);
   const [buscaAluno, setBuscaAluno] = useState("");
   const [loading, setLoading] = useState(false);
-  const [tab, setTab] = useState("gerenciar");
-  
-  // Estados para criação/edição de grupo
-  const [novoGrupo, setNovoGrupo] = useState({ nome: "", descricao: "" });
   const [editandoGrupo, setEditandoGrupo] = useState<string | null>(null);
 
   // Carregar dados iniciais
@@ -105,7 +92,6 @@ export function ModalGerenciarGrupos({
     try {
       const response = await apiClient.get(`/api/users/${professorId}/grupos/${grupoId}/alunos`);
       const membros = response.data || [];
-      
       setGrupos(prev => prev.map(grupo => 
         grupo.id === grupoId ? { ...grupo, membros } : grupo
       ));
@@ -165,25 +151,7 @@ export function ModalGerenciarGrupos({
     }
   };
 
-  const criarGrupo = async () => {
-    if (!novoGrupo.nome.trim()) return;
-    
-    setLoading(true);
-    try {
-      await apiClient.post(`/api/users/${professorId}/grupos`, novoGrupo);
-      await carregarDados();
-      setNovoGrupo({ nome: "", descricao: "" });
-      
-      if (onGrupoChange) onGrupoChange();
-    } catch (error) {
-      console.error("Erro ao criar grupo:", error);
-      alert("Erro ao criar grupo");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const editarGrupo = async (grupoId: string, dados: { nome: string; descricao?: string }) => {
+  const editarGrupo = async (grupoId: string, dados: { nome: string }) => {
     setLoading(true);
     try {
       await apiClient.put(`/api/users/${professorId}/grupos/${grupoId}`, dados);
@@ -241,6 +209,7 @@ export function ModalGerenciarGrupos({
     return !grupo?.membros?.some(membro => membro.id === aluno.id);
   });
 
+  // Remove tabs, exibe todos os grupos em cards para seleção
   return (
     <ModalPadrao
       open={open}
@@ -254,269 +223,199 @@ export function ModalGerenciarGrupos({
       description="Organize seus alunos em grupos e equipes"
       maxWidth="2xl"
     >
-      <Tabs value={tab} onValueChange={setTab} className="w-full">
-        <TabsList className="grid w-full grid-cols-3">
-          <TabsTrigger value="gerenciar">Gerenciar Membros</TabsTrigger>
-          <TabsTrigger value="grupos">Meus Grupos</TabsTrigger>
-          <TabsTrigger value="novo">Criar Grupo</TabsTrigger>
-        </TabsList>
-
-        {/* Aba: Gerenciar Membros */}
-        <TabsContent value="gerenciar" className="space-y-4">
-          {grupos.length === 0 ? (
-            <Card>
-              <CardContent className="pt-6 text-center">
-                <Users className="h-12 w-12 mx-auto text-gray-400 mb-2" />
-                <p className="text-gray-500">Nenhum grupo criado ainda.</p>
-                <p className="text-sm text-gray-400">Crie seu primeiro grupo na aba &quot;Criar Grupo&quot;</p>
-              </CardContent>
-            </Card>
-          ) : (
-            <>
-              <div className="space-y-2">
-                <Label>Selecionar Grupo</Label>
-                <Select value={grupoSelecionado} onValueChange={(value) => {
-                  setGrupoSelecionado(value);
-                  if (value) carregarMembrosGrupo(value);
-                }}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Escolha um grupo para gerenciar" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {grupos.map(grupo => (
-                      <SelectItem key={grupo.id} value={grupo.id}>
-                        {grupo.nome}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {grupoSelecionado && (
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  {/* Lista de alunos disponíveis */}
-                  <Card>
-                    <CardHeader>
-                      <CardTitle className="text-sm font-medium flex items-center gap-2">
-                        <UserPlus className="h-4 w-4" />
-                        Adicionar Alunos
-                      </CardTitle>
-                      <div className="relative">
-                        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-                        <Input
-                          placeholder="Buscar aluno..."
-                          value={buscaAluno}
-                          onChange={(e) => setBuscaAluno(e.target.value)}
-                          className="pl-10"
-                        />
-                      </div>
-                    </CardHeader>
-                    <CardContent className="space-y-2 max-h-64 overflow-y-auto">
-                      {alunosDisponiveis.map(aluno => (
-                        <div key={aluno.id} className="flex items-center space-x-2 p-2 hover:bg-gray-50 rounded">
-                          <Checkbox
-                            checked={alunosSelecionados.includes(aluno.id)}
-                            onCheckedChange={(checked) => {
-                              if (checked) {
-                                setAlunosSelecionados([...alunosSelecionados, aluno.id]);
-                              } else {
-                                setAlunosSelecionados(alunosSelecionados.filter(id => id !== aluno.id));
-                              }
-                            }}
-                          />
-                          <Avatar className="h-8 w-8">
-                            <AvatarImage src={aluno.image || undefined} />
-                            <AvatarFallback className="text-xs">
-                              {getInitials(aluno.name)}
-                            </AvatarFallback>
-                          </Avatar>
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium truncate">{formatDisplayName(aluno.name)}</p>
-                            <p className="text-xs text-gray-500 truncate">{formatDisplayEmail(aluno.email)}</p>
-                          </div>
-                        </div>
-                      ))}
-                      {alunosDisponiveis.length === 0 && (
-                        <p className="text-sm text-gray-500 text-center py-4">
-                          {buscaAluno ? "Nenhum aluno encontrado" : "Todos os alunos já estão no grupo"}
-                        </p>
-                      )}
-                    </CardContent>
-                  </Card>
-
-                  {/* Membros do grupo */}
-                  <Card>
-                    <CardHeader>
-                      <CardTitle className="text-sm font-medium flex items-center gap-2">
-                        <Users className="h-4 w-4" />
-                        Membros do Grupo ({grupos.find(g => g.id === grupoSelecionado)?.membros?.length || 0})
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-2 max-h-64 overflow-y-auto">
-                      {grupos.find(g => g.id === grupoSelecionado)?.membros?.map(membro => (
-                        <div key={membro.id} className="flex items-center justify-between p-2 bg-gray-50 rounded">
-                          <div className="flex items-center space-x-2">
-                            <Avatar className="h-8 w-8">
-                              <AvatarImage src={membro.image || undefined} />
-                              <AvatarFallback className="text-xs">
-                                {getInitials(membro.name)}
-                              </AvatarFallback>
-                            </Avatar>
-                            <div className="flex-1 min-w-0">
-                              <p className="text-sm font-medium truncate">{formatDisplayName(membro.name)}</p>
-                              <p className="text-xs text-gray-500 truncate">{formatDisplayEmail(membro.email)}</p>
-                            </div>
-                          </div>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            onClick={() => removerAlunoDoGrupo(grupoSelecionado, membro.id)}
-                            disabled={loading}
-                          >
-                            <UserMinus className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      )) || []}
-                      {(!grupos.find(g => g.id === grupoSelecionado)?.membros?.length) && (
-                        <p className="text-sm text-gray-500 text-center py-4">
-                          Nenhum membro no grupo
-                        </p>
-                      )}
-                    </CardContent>
-                  </Card>
-                </div>
-              )}
-
-              {grupoSelecionado && alunosSelecionados.length > 0 && (
-                <div className="flex justify-end">
-                  <Button onClick={adicionarAlunosAoGrupo} disabled={loading}>
-                    <UserPlus className="h-4 w-4 mr-2" />
-                    Adicionar {alunosSelecionados.length} aluno(s)
-                  </Button>
-                </div>
-              )}
-            </>
-          )}
-        </TabsContent>
-
-        {/* Aba: Meus Grupos */}
-        <TabsContent value="grupos" className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {grupos.map(grupo => (
-              <Card key={grupo.id}>
-                <CardHeader>
-                  <div className="flex items-center justify-between">
+      <div className="space-y-6">
+        {/* Lista de grupos em cards para seleção */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {grupos.map(grupo => (
+            <Card
+              key={grupo.id}
+              className={`cursor-pointer border-2 transition-all ${grupoSelecionado === grupo.id ? 'border-blue-600 shadow-lg' : 'border-gray-200'}`}
+              onClick={() => {
+                setGrupoSelecionado(grupo.id);
+                carregarMembrosGrupo(grupo.id);
+              }}
+            >
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <div className="flex-1">
                     {editandoGrupo === grupo.id ? (
-                      <div className="flex-1 space-y-2">
+                      <form
+                        className="space-y-2"
+                        onSubmit={async (e) => {
+                          e.preventDefault();
+                          const form = e.target as HTMLFormElement;
+                          const nome = (form.elements.namedItem('nome') as HTMLInputElement).value;
+                          await editarGrupo(grupo.id, { nome });
+                        }}
+                      >
                         <Input
+                          name="nome"
                           defaultValue={grupo.nome}
-                          onBlur={(e) => {
-                            if (e.target.value.trim() && e.target.value !== grupo.nome) {
-                              editarGrupo(grupo.id, { 
-                                nome: e.target.value.trim(),
-                                descricao: grupo.descricao 
-                              });
-                            } else {
-                              setEditandoGrupo(null);
-                            }
-                          }}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter') {
-                              e.currentTarget.blur();
-                            } else if (e.key === 'Escape') {
-                              setEditandoGrupo(null);
-                            }
-                          }}
+                          placeholder="Nome do grupo"
+                          className="mb-1"
+                          required
+                          maxLength={50}
                           autoFocus
                         />
-                      </div>
+                        <div className="flex gap-2 mt-2">
+                          <Button size="sm" type="submit" variant="default">
+                            <Save className="h-4 w-4 mr-1" /> Salvar
+                          </Button>
+                          <Button size="sm" type="button" variant="ghost" onClick={e => { e.stopPropagation(); setEditandoGrupo(null); }}>
+                            <X className="h-4 w-4" /> Cancelar
+                          </Button>
+                        </div>
+                      </form>
                     ) : (
-                      <div className="flex-1">
+                      <>
                         <CardTitle className="text-lg">{grupo.nome}</CardTitle>
-                        {grupo.descricao && (
-                          <p className="text-sm text-gray-500">{grupo.descricao}</p>
-                        )}
-                      </div>
+                      </>
                     )}
-                    <div className="flex items-center gap-1">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => setEditandoGrupo(editandoGrupo === grupo.id ? null : grupo.id)}
-                      >
-                        {editandoGrupo === grupo.id ? <X className="h-4 w-4" /> : <Edit className="h-4 w-4" />}
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => excluirGrupo(grupo.id)}
-                        disabled={loading}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
                   </div>
-                </CardHeader>
-                <CardContent>
-                  <div className="flex items-center gap-2 text-sm text-gray-600">
-                    <Users className="h-4 w-4" />
-                    <span>{grupo.membros?.length || 0} membros</span>
-                    <Badge variant="outline" className="ml-auto">
-                      {new Date(grupo.criadoEm).toLocaleDateString('pt-BR')}
-                    </Badge>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={e => { e.stopPropagation(); setEditandoGrupo(editandoGrupo === grupo.id ? null : grupo.id); }}
+                    >
+                      {editandoGrupo === grupo.id ? <X className="h-4 w-4" /> : <Edit className="h-4 w-4" />}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={e => { e.stopPropagation(); excluirGrupo(grupo.id); }}
+                      disabled={loading}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
                   </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-
-          {grupos.length === 0 && (
-            <Card>
-              <CardContent className="pt-6 text-center">
-                <Users className="h-12 w-12 mx-auto text-gray-400 mb-2" />
-                <p className="text-gray-500">Nenhum grupo criado ainda.</p>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <Users className="h-4 w-4" />
+                  <span>{grupo.membros?.length || 0} membros</span>
+                  <Badge variant="outline" className="ml-auto">
+                    {new Date(grupo.criadoEm).toLocaleDateString('pt-BR')}
+                  </Badge>
+                </div>
               </CardContent>
             </Card>
-          )}
-        </TabsContent>
-
-        {/* Aba: Criar Grupo */}
-        <TabsContent value="novo" className="space-y-4">
+          ))}
+        </div>
+        {grupos.length === 0 && (
           <Card>
-            <CardHeader>
-              <CardTitle>Criar Novo Grupo</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="nome">Nome do Grupo *</Label>
-                <Input
-                  id="nome"
-                  placeholder="Ex: Equipe de Vôlei, Turma Manhã..."
-                  value={novoGrupo.nome}
-                  onChange={(e) => setNovoGrupo({ ...novoGrupo, nome: e.target.value })}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="descricao">Descrição (opcional)</Label>
-                <Input
-                  id="descricao"
-                  placeholder="Descrição do grupo..."
-                  value={novoGrupo.descricao}
-                  onChange={(e) => setNovoGrupo({ ...novoGrupo, descricao: e.target.value })}
-                />
-              </div>
-              <Button 
-                onClick={criarGrupo} 
-                disabled={loading || !novoGrupo.nome.trim()}
-                className="w-full"
-              >
-                <Save className="h-4 w-4 mr-2" />
-                {loading ? "Criando..." : "Criar Grupo"}
-              </Button>
+            <CardContent className="pt-6 text-center">
+              <Users className="h-12 w-12 mx-auto text-gray-400 mb-2" />
+              <p className="text-gray-500">Nenhum grupo criado ainda.</p>
             </CardContent>
           </Card>
-        </TabsContent>
-      </Tabs>
+        )}
+
+        {/* Gerenciamento de membros do grupo selecionado */}
+        {grupoSelecionado && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
+            {/* Lista de alunos disponíveis */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-sm font-medium flex items-center gap-2">
+                  <UserPlus className="h-4 w-4" />
+                  Adicionar Alunos
+                </CardTitle>
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                  <Input
+                    placeholder="Buscar aluno..."
+                    value={buscaAluno}
+                    onChange={(e) => setBuscaAluno(e.target.value)}
+                    className="pl-10"
+                  />
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-2 max-h-64 overflow-y-auto">
+                {alunosDisponiveis.map(aluno => (
+                  <div key={aluno.id} className="flex items-center space-x-2 p-2 hover:bg-gray-50 rounded">
+                    <Checkbox
+                      checked={alunosSelecionados.includes(aluno.id)}
+                      onCheckedChange={(checked) => {
+                        if (checked) {
+                          setAlunosSelecionados([...alunosSelecionados, aluno.id]);
+                        } else {
+                          setAlunosSelecionados(alunosSelecionados.filter(id => id !== aluno.id));
+                        }
+                      }}
+                    />
+                    <Avatar className="h-8 w-8">
+                      <AvatarImage src={aluno.image || undefined} />
+                      <AvatarFallback className="text-xs">
+                        {getInitials(aluno.name)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium truncate">{formatDisplayName(aluno.name)}</p>
+                      <p className="text-xs text-gray-500 truncate">{formatDisplayEmail(aluno.email)}</p>
+                    </div>
+                  </div>
+                ))}
+                {alunosDisponiveis.length === 0 && (
+                  <p className="text-sm text-gray-500 text-center py-4">
+                    {buscaAluno ? "Nenhum aluno encontrado" : "Todos os alunos já estão no grupo"}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Membros do grupo */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-sm font-medium flex items-center gap-2">
+                  <Users className="h-4 w-4" />
+                  Membros do Grupo ({grupos.find(g => g.id === grupoSelecionado)?.membros?.length || 0})
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 max-h-64 overflow-y-auto">
+                {grupos.find(g => g.id === grupoSelecionado)?.membros?.map(membro => (
+                  <div key={membro.id} className="flex items-center justify-between p-2 bg-gray-50 rounded">
+                    <div className="flex items-center space-x-2">
+                      <Avatar className="h-8 w-8">
+                        <AvatarImage src={membro.image || undefined} />
+                        <AvatarFallback className="text-xs">
+                          {getInitials(membro.name)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium truncate">{formatDisplayName(membro.name)}</p>
+                        <p className="text-xs text-gray-500 truncate">{formatDisplayEmail(membro.email)}</p>
+                      </div>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => removerAlunoDoGrupo(grupoSelecionado, membro.id)}
+                      disabled={loading}
+                    >
+                      <UserMinus className="h-4 w-4" />
+                    </Button>
+                  </div>
+                )) || []}
+                {(!grupos.find(g => g.id === grupoSelecionado)?.membros?.length) && (
+                  <p className="text-sm text-gray-500 text-center py-4">
+                    Nenhum membro no grupo
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        )}
+        {grupoSelecionado && alunosSelecionados.length > 0 && (
+          <div className="flex justify-end mt-4">
+            <Button onClick={adicionarAlunosAoGrupo} disabled={loading}>
+              <UserPlus className="h-4 w-4 mr-2" />
+              Adicionar {alunosSelecionados.length} aluno(s)
+            </Button>
+          </div>
+        )}
+      </div>
     </ModalPadrao>
   );
 }

--- a/apcpro-web/src/components/ModalMedidasCorporais.tsx
+++ b/apcpro-web/src/components/ModalMedidasCorporais.tsx
@@ -12,13 +12,11 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import Image from "next/image";
 import { useSession } from "next-auth/react";
 import apiClient from "@/lib/api-client";
-import type { AvaliacaoCompleta } from "@/types/dobras-cutaneas";
 import {
   avaliarCA,
   CircunferenciaAbdominalResultado,
 } from "@/services/ca-service";
 import { CaInfo } from "./CaInfo";
-import { DobrasCutaneasModernas } from "./DobrasCutaneasModernas";
 import { useUserProfile } from "@/contexts/UserProfileContext";
 
 // Service que chama a API de medidas
@@ -150,7 +148,6 @@ export function ModalMedidasCorporais({
   const [loading, setLoading] = useState(false);
   const [resultadoCA] = useState<CircunferenciaAbdominalResultado | null>(null);
   const [activeTab, setActiveTab] = useState("medidas");
-  const [dobrasCutaneasResultados, setDobrasCutaneasResultados] = useState<AvaliacaoCompleta | null>(null);
   const { profile } = useUserProfile();
 
   // Verifica se o usuário é professor
@@ -167,11 +164,6 @@ export function ModalMedidasCorporais({
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     setForm({ ...form, [e.target.id]: e.target.value });
-  }
-
-  // Callback para receber os resultados das dobras cutâneas
-  function handleDobrasCutaneasResultados(resultados: AvaliacaoCompleta) {
-    setDobrasCutaneasResultados(resultados);
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -226,7 +218,7 @@ export function ModalMedidasCorporais({
           : undefined,
       },
       // Adiciona os resultados das dobras cutâneas se disponíveis
-      dobrasCutaneas: dobrasCutaneasResultados,
+      dobrasCutaneas: undefined,
     };
 
     // Chama a API que já retorna todos os índices, inclusive CA
@@ -284,240 +276,219 @@ export function ModalMedidasCorporais({
       maxWidth="lg"
     >
       <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-        <TabsList className="grid w-full grid-cols-2">
+        <TabsList className="grid w-full grid-cols-1">
           <TabsTrigger value="medidas">Medidas Corporais</TabsTrigger>
-          <TabsTrigger 
-            value="dobras"
-            className={!isUserProfessor ? "opacity-50 cursor-not-allowed" : ""}
-          >
-            Dobras Cutâneas {!isUserProfessor && "🔒"}
-          </TabsTrigger>
+          {/* Removido: Aba Dobras Cutâneas */}
         </TabsList>
 
-              <TabsContent value="medidas" className="space-y-4">
-                <form className="flex flex-col gap-1" onSubmit={handleSubmit}>
-                  {/* PESO E ALTURA CENTRALIZADOS EM 2 COLUNAS */}
-                  <div className="grid grid-cols-2 gap-x-8 mb-4">
-                    <div className="flex flex-col items-center">
-                      <LabelWithTooltip
-                        htmlFor="peso"
-                        label="Peso (kg)"
-                        tooltip="Informe o peso corporal atual em quilogramas."
-                      />
-                      <Input
-                        id="peso"
-                        className="w-28"
-                        placeholder="Ex: 70"
-                        type="number"
-                        step="0.01"
-                        value={form.peso || ""}
-                        onChange={handleChange}
-                        required
-                      />
-                    </div>
-                    <div className="flex flex-col items-center">
-                      <LabelWithTooltip
-                        htmlFor="altura"
-                        label="Altura (cm)"
-                        tooltip="Informe a altura em centímetros, sem sapatos."
-                      />
-                      <Input
-                        id="altura"
-                        className="w-28"
-                        placeholder="Ex: 175"
-                        type="number"
-                        step="0.1"
-                        value={form.altura || ""}
-                        onChange={handleChange}
-                        required
-                      />
-                    </div>
-                  </div>
+        <TabsContent value="medidas" className="space-y-4">
+          <form className="flex flex-col gap-1" onSubmit={handleSubmit}>
+            {/* PESO E ALTURA CENTRALIZADOS EM 2 COLUNAS */}
+            <div className="grid grid-cols-2 gap-x-8 mb-4">
+              <div className="flex flex-col items-center">
+                <LabelWithTooltip
+                  htmlFor="peso"
+                  label="Peso (kg)"
+                  tooltip="Informe o peso corporal atual em quilogramas."
+                />
+                <Input
+                  id="peso"
+                  className="w-28"
+                  placeholder="Ex: 70"
+                  type="number"
+                  step="0.01"
+                  value={form.peso || ""}
+                  onChange={handleChange}
+                  required
+                />
+              </div>
+              <div className="flex flex-col items-center">
+                <LabelWithTooltip
+                  htmlFor="altura"
+                  label="Altura (cm)"
+                  tooltip="Informe a altura em centímetros, sem sapatos."
+                />
+                <Input
+                  id="altura"
+                  className="w-28"
+                  placeholder="Ex: 175"
+                  type="number"
+                  step="0.1"
+                  value={form.altura || ""}
+                  onChange={handleChange}
+                  required
+                />
+              </div>
+            </div>
 
-                  {/* Inputs centrais acima da imagem, divididos em 3 colunas */}
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-x-8 gap-y-2 mb-2">
-                    <div className="flex flex-col items-center gap-2">
-                      <div>
-                        <LabelWithTooltip
-                          htmlFor="pescoco"
-                          label="Pescoço"
-                          tooltip="Meça logo abaixo da laringe (pomo de Adão)."
-                        />
-                        <Input
-                          id="pescoco"
-                          className="w-28"
-                          placeholder="cm"
-                          type="number"
-                          value={form.pescoco || ""}
-                          onChange={handleChange}
-                          required
-                        />
-                      </div>
-                      <div>
-                        <LabelWithTooltip
-                          htmlFor="torax"
-                          label="Tórax"
-                          tooltip="Meça a circunferência do tórax na linha dos mamilos, com os braços relaxados."
-                        />
-                        <Input
-                          id="torax"
-                          className="w-28"
-                          placeholder="cm"
-                          type="number"
-                          value={form.torax || ""}
-                          onChange={handleChange}
-                          required
-                        />
-                      </div>
-                    </div>
-                    <div className="flex flex-col items-center gap-2">
-                      <div>
-                        <LabelWithTooltip
-                          htmlFor="cintura"
-                          label="Cintura"
-                          tooltip="Homens: ao nível do umbigo. Mulheres: parte mais estreita do abdômen."
-                        />
-                        <Input
-                          id="cintura"
-                          className="w-28"
-                          placeholder="cm"
-                          type="number"
-                          value={form.cintura || ""}
-                          onChange={handleChange}
-                          required
-                        />
-                      </div>
-                    </div>
-                    <div className="flex flex-col items-center gap-2">
-                      <div>
-                        <LabelWithTooltip
-                          htmlFor="quadril"
-                          label="Quadril"
-                          tooltip="Meça na parte mais larga dos glúteos."
-                        />
-                        <Input
-                          id="quadril"
-                          className="w-28"
-                          placeholder="cm"
-                          type="number"
-                          value={form.quadril || ""}
-                          onChange={handleChange}
-                          required
-                        />
-                      </div>
-                      <div>
-                        <LabelWithTooltip
-                          htmlFor="abdomen"
-                          label="Abdômen"
-                          tooltip="Meça a circunferência abdominal na altura do umbigo."
-                        />
-                        <Input
-                          id="abdomen"
-                          className="w-28"
-                          placeholder="cm"
-                          type="number"
-                          value={form.abdomen || ""}
-                          onChange={handleChange}
-                          required
-                        />
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Inputs laterais e imagem central */}
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-x-8 gap-y-2 items-start">
-                    {/* Coluna esquerda */}
-                    <div className="flex flex-col items-center gap-2">
-                      {bodyParts
-                        .filter((part) => part.side === "left")
-                        .map((part) => (
-                          <div key={part.id}>
-                            <LabelWithTooltip
-                              htmlFor={part.id}
-                              label={part.label}
-                              tooltip={
-                                part.tooltip ||
-                                "Meça a circunferência na parte indicada, mantendo a fita confortável e nivelada."
-                              }
-                            />
-                            <Input
-                              id={part.id}
-                              className="w-28"
-                              placeholder="cm"
-                              type="number"
-                              value={form[part.id] || ""}
-                              onChange={handleChange}
-                              required
-                            />
-                          </div>
-                        ))}
-                    </div>
-                    {/* Imagem central */}
-                    <div className="flex flex-col items-center gap-2">
-                      <Image
-                        src="/images/human-silhouette.png"
-                        alt="Figura medidas corporais"
-                        width={220}
-                        height={370}
-                        style={{ maxWidth: "100%", height: "auto" }}
-                      />
-                    </div>
-                    {/* Coluna direita */}
-                    <div className="flex flex-col items-center gap-2">
-                      {bodyParts
-                        .filter((part) => part.side === "right")
-                        .map((part) => (
-                          <div key={part.id}>
-                            <LabelWithTooltip
-                              htmlFor={part.id}
-                              label={part.label}
-                              tooltip={
-                                part.tooltip ||
-                                "Meça a circunferência na parte indicada, mantendo a fita confortável e nivelada."
-                              }
-                            />
-                            <Input
-                              id={part.id}
-                              className="w-28"
-                              placeholder="cm"
-                              type="number"
-                              value={form[part.id] || ""}
-                              onChange={handleChange}
-                              required
-                            />
-                          </div>
-                        ))}
-                    </div>
-                  </div>
-
-                  {/* Botão de envio */}
-                  <div className="flex justify-end mt-6 p-4">
-                    <Button type="submit" disabled={loading}>
-                      {loading ? "Salvando..." : "Salvar Avaliação"}
-                    </Button>
-                  </div>
-                </form>
-                {/* Exibe o resultado do CA se existir */}
-                {resultadoCA && <CaInfo resultado={resultadoCA} />}
-              </TabsContent>
-
-              <TabsContent value="dobras" className="space-y-4">
-                {form.peso && form.altura ? (
-                  <DobrasCutaneasModernas
-                    userPerfilId={profile?.id}
-                    onResultado={handleDobrasCutaneasResultados}
-                    modoCalculoApenas={false}
-                    className="mt-4"
+            {/* Inputs centrais acima da imagem, divididos em 3 colunas */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-x-8 gap-y-2 mb-2">
+              <div className="flex flex-col items-center gap-2">
+                <div>
+                  <LabelWithTooltip
+                    htmlFor="pescoco"
+                    label="Pescoço"
+                    tooltip="Meça logo abaixo da laringe (pomo de Adão)."
                   />
-                ) : (
-                <div className="p-6 text-center">
-                  <p className="text-muted-foreground">
-                    Para calcular as dobras cutâneas, primeiro preencha o peso e altura na aba &quot;Medidas Corporais&quot;.
-                  </p>
+                  <Input
+                    id="pescoco"
+                    className="w-28"
+                    placeholder="cm"
+                    type="number"
+                    value={form.pescoco || ""}
+                    onChange={handleChange}
+                    required
+                  />
                 </div>
-              )}
-            </TabsContent>
-          </Tabs>
+                <div>
+                  <LabelWithTooltip
+                    htmlFor="torax"
+                    label="Tórax"
+                    tooltip="Meça a circunferência do tórax na linha dos mamilos, com os braços relaxados."
+                  />
+                  <Input
+                    id="torax"
+                    className="w-28"
+                    placeholder="cm"
+                    type="number"
+                    value={form.torax || ""}
+                    onChange={handleChange}
+                    required
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col items-center gap-2">
+                <div>
+                  <LabelWithTooltip
+                    htmlFor="cintura"
+                    label="Cintura"
+                    tooltip="Homens: ao nível do umbigo. Mulheres: parte mais estreita do abdômen."
+                  />
+                  <Input
+                    id="cintura"
+                    className="w-28"
+                    placeholder="cm"
+                    type="number"
+                    value={form.cintura || ""}
+                    onChange={handleChange}
+                    required
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col items-center gap-2">
+                <div>
+                  <LabelWithTooltip
+                    htmlFor="quadril"
+                    label="Quadril"
+                    tooltip="Meça na parte mais larga dos glúteos."
+                  />
+                  <Input
+                    id="quadril"
+                    className="w-28"
+                    placeholder="cm"
+                    type="number"
+                    value={form.quadril || ""}
+                    onChange={handleChange}
+                    required
+                  />
+                </div>
+                <div>
+                  <LabelWithTooltip
+                    htmlFor="abdomen"
+                    label="Abdômen"
+                    tooltip="Meça a circunferência abdominal na altura do umbigo."
+                  />
+                  <Input
+                    id="abdomen"
+                    className="w-28"
+                    placeholder="cm"
+                    type="number"
+                    value={form.abdomen || ""}
+                    onChange={handleChange}
+                    required
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Inputs laterais e imagem central */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-x-8 gap-y-2 items-start">
+              {/* Coluna esquerda */}
+              <div className="flex flex-col items-center gap-2">
+                {bodyParts
+                  .filter((part) => part.side === "left")
+                  .map((part) => (
+                    <div key={part.id}>
+                      <LabelWithTooltip
+                        htmlFor={part.id}
+                        label={part.label}
+                        tooltip={
+                          part.tooltip ||
+                          "Meça a circunferência na parte indicada, mantendo a fita confortável e nivelada."
+                        }
+                      />
+                      <Input
+                        id={part.id}
+                        className="w-28"
+                        placeholder="cm"
+                        type="number"
+                        value={form[part.id] || ""}
+                        onChange={handleChange}
+                        required
+                      />
+                    </div>
+                  ))}
+              </div>
+              {/* Imagem central */}
+              <div className="flex flex-col items-center gap-2">
+                <Image
+                  src="/images/human-silhouette.png"
+                  alt="Figura medidas corporais"
+                  width={220}
+                  height={370}
+                  style={{ maxWidth: "100%", height: "auto" }}
+                />
+              </div>
+              {/* Coluna direita */}
+              <div className="flex flex-col items-center gap-2">
+                {bodyParts
+                  .filter((part) => part.side === "right")
+                  .map((part) => (
+                    <div key={part.id}>
+                      <LabelWithTooltip
+                        htmlFor={part.id}
+                        label={part.label}
+                        tooltip={
+                          part.tooltip ||
+                          "Meça a circunferência na parte indicada, mantendo a fita confortável e nivelada."
+                        }
+                      />
+                      <Input
+                        id={part.id}
+                        className="w-28"
+                        placeholder="cm"
+                        type="number"
+                        value={form[part.id] || ""}
+                        onChange={handleChange}
+                        required
+                      />
+                    </div>
+                  ))}
+              </div>
+            </div>
+
+            {/* Botão de envio */}
+            <div className="flex justify-end mt-6 p-4">
+              <Button type="submit" disabled={loading}>
+                {loading ? "Salvando..." : "Salvar Avaliação"}
+              </Button>
+            </div>
+          </form>
+          {/* Exibe o resultado do CA se existir */}
+          {resultadoCA && <CaInfo resultado={resultadoCA} />}
+        </TabsContent>
+        {/* Removido: TabsContent de Dobras Cutâneas */}
+      </Tabs>
     </ModalPadrao>
   );
 }

--- a/apcpro-web/src/components/team-switcher.tsx
+++ b/apcpro-web/src/components/team-switcher.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { ChevronsUpDown, Plus, Users, LucideProps } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { LoadingInline, LoadingSkeleton } from "@/components/ui/Loading";
+import { LoadingInline } from "@/components/ui/Loading";
 
 import {
   DropdownMenu,
@@ -45,9 +45,10 @@ type Grupo = {
 interface TeamSwitcherProps {
   teams?: Team[];
   onTeamChange?: (groupId: string | null) => void;
+  onGerenciarGruposClick?: () => void;
 }
 
-export function TeamSwitcher({ teams = [], onTeamChange }: TeamSwitcherProps) {
+export function TeamSwitcher({ teams = [], onTeamChange, onGerenciarGruposClick }: TeamSwitcherProps) {
   const { isMobile } = useSidebar();
   const { profile } = useUserProfile();
   
@@ -230,6 +231,20 @@ export function TeamSwitcher({ teams = [], onTeamChange }: TeamSwitcherProps) {
                 )}
               </div>
             </DropdownMenuItem>
+            {/* Item Gerenciar Grupos como menu item, dispara callback */}
+            {onGerenciarGruposClick && (
+              <DropdownMenuItem
+                className="gap-2 p-2 cursor-pointer"
+                onClick={onGerenciarGruposClick}
+              >
+                <div className="flex size-6 items-center justify-center rounded-md border bg-transparent">
+                  <Users className="size-4" />
+                </div>
+                <div className="text-muted-foreground font-medium flex items-center gap-2">
+                  Gerenciar Grupos
+                </div>
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
         


### PR DESCRIPTION
- Updated ExemploDashboardCompleto to use HTML entities for quotes in LoadingSkeleton examples.
- Replaced <img> with <Image> component in ExemplosLoading for better image handling.
- Removed unused LoadingSkeleton import in ModalAvaliacaoCompleta.
- Modified ModalAvaliacaoCompleta to conditionally add skinfold measurement step for professors only.
- Simplified ModalGerenciarGrupos by removing tabs and displaying groups in cards for selection.
- Updated ModalMedidasCorporais to remove the Dobras Cutâneas tab and related logic.
- Added a "Gerenciar Grupos" option in TeamSwitcher dropdown menu.