### PR TITLE
remover: excluir página de exemplo para skeletons do dashboard

### DIFF
--- a/apcpro-web/src/app/dashboard/exemplo-skeletons/page.tsx
+++ b/apcpro-web/src/app/dashboard/exemplo-skeletons/page.tsx
@@ -1,9 +1,0 @@
-import { ExemploDashboardCompleto } from "@/components/ExemploDashboardCompleto";
-
-/**
- * Página de exemplo para testar os skeletons do dashboard
- * Acesse: /dashboard/exemplo-skeletons
- */
-export default function ExemploSkeletonsPage() {
-  return <ExemploDashboardCompleto />;
-}


### PR DESCRIPTION
This pull request removes an example page used for testing dashboard skeletons in the `apcpro-web` project. The primary change involves deleting the `ExemploSkeletonsPage` component and its associated import.

### Removal of example page:

* [`apcpro-web/src/app/dashboard/exemplo-skeletons/page.tsx`](diffhunk://#diff-6f02410ab0269b801ecd735ee982b7e92afed2cebfb32fa3e891461560c42382L1-L9): Deleted the `ExemploSkeletonsPage` component, which was previously used as an example for testing dashboard skeletons. This includes the removal of the `ExemploDashboardCompleto` import and the component's implementation.